### PR TITLE
fix bugs for range in RTree, and some mistakes in Treap

### DIFF
--- a/engine/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
+++ b/engine/sql/core/src/main/scala/org/apache/spark/sql/SQLConf.scala
@@ -497,11 +497,9 @@ private[spark] object SQLConf {
 
   val INDEX_SELECTIVITY_LEVEL =
     intConf("spark.sql.index.selectivityLevel",
-      defaultValue = Some(0),
+      defaultValue = Some(1),
       doc = "This only works when INDEX_SELECTIVITY_ENABLE is true." +
-        "Simab consider predicates selectivity from level 0 " +
-        "(root level, include) to the specified level (also incldue) " +
-        "in local RTree index. The default value is 0.")
+        "Simab considers predicates selectivity from this level, default root level (1)")
 
   // Threshold determine where rtree index using local index or brute force filter
   val INDEX_SIZE_THRESHOLD = intConf("spark.sql.index.threshold", defaultValue = Some(1000))

--- a/engine/sql/core/src/main/scala/org/apache/spark/sql/index/IndexedRelationScan.scala
+++ b/engine/sql/core/src/main/scala/org/apache/spark/sql/index/IndexedRelationScan.scala
@@ -60,10 +60,10 @@ private[sql] case class IndexedRelationScan(attributes: Seq[Attribute],
                                             relation: IndexedRelation)
   extends LeafNode with PredicateHelper {
 
-  private def selectivity_enabled = sqlContext.conf.indexSelectivityEnable
-  private def s_level_limit = sqlContext.conf.indexSelectivityLevel
-  private def s_threshold = sqlContext.conf.indexSelectivityThreshold
-  private def index_threshold = sqlContext.conf.indexSizeThreshold
+  private val selectivity_enabled = sqlContext.conf.indexSelectivityEnable
+  private val s_level_limit = sqlContext.conf.indexSelectivityLevel
+  private val s_threshold = sqlContext.conf.indexSelectivityThreshold
+  private val index_threshold = sqlContext.conf.indexSizeThreshold
 
   def getLeafInterval(x: Expression): (Interval, Attribute) = {
     x match {
@@ -174,7 +174,7 @@ private[sql] case class IndexedRelationScan(attributes: Seq[Attribute],
               if (interval != null && !interval.isNull) {
                 val tmp = index.range(interval.min._1, interval.max._1)
                 tmp_res ++= tmp
-                if (interval.max._2) tmp_res ++= index.find(interval.max._1)
+              //  if (interval.max._2) tmp_res ++= index.find(interval.max._1)
               }
             }
             tmp_res.toArray.distinct.map(t => packed.data(t))
@@ -299,7 +299,7 @@ private[sql] case class IndexedRelationScan(attributes: Seq[Attribute],
                             .eval(row).asInstanceOf[Number].doubleValue()).toArray
                         )
                         queryMBR.intersects(tmp_point)
-                      }
+                      }.intersect(index.circleRangeConj(cir_ranges).map(x => packed.data(x._2)))
                     } else {
                       res.get.map(x => packed.data(x._2))
                         .intersect(index.circleRangeConj(cir_ranges).map(x => packed.data(x._2)))

--- a/engine/sql/core/src/main/scala/org/apache/spark/sql/index/RTree.scala
+++ b/engine/sql/core/src/main/scala/org/apache/spark/sql/index/RTree.scala
@@ -96,7 +96,7 @@ case class RTree(root: RTreeNode) extends Index with Serializable {
     import loop.{break, breakable}
     breakable {
       while (q.nonEmpty) {
-        val now = q.front
+        val now = q.dequeue
         val cur_node = now._1
         val cur_level = now._2
         if (cur_node.isLeaf) {
@@ -111,13 +111,17 @@ case class RTree(root: RTreeNode) extends Index with Serializable {
           }
         } else if (cur_level == level_limit) {
           estimate += cur_node.m_mbr.calcRatio(query) * cur_node.size
+          cur_node.m_child.foreach {
+            case RTreeInternalEntry(mbr, node) =>
+              if (query.intersects(mbr)) q.enqueue((node, cur_level + 1))
+          }
         } else break
       }
     }
     if (ans.nonEmpty) return Some(ans.toArray)
     else if (estimate / root.size > s_threshold) return None
     while (q.nonEmpty) {
-      val now = q.front
+      val now = q.dequeue
       val cur_node = now._1
       val cur_level = now._2
       if (cur_node.isLeaf) {

--- a/engine/sql/core/src/main/scala/org/apache/spark/sql/index/Treap.scala
+++ b/engine/sql/core/src/main/scala/org/apache/spark/sql/index/Treap.scala
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2016 by Simba Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.spark.sql.index
 
 import org.apache.spark.sql.catalyst.InternalRow
@@ -15,7 +31,7 @@ case class TreapNode[K](key: K, var data: Array[Int],
                         rand: Long, var size: Int, var count: Int) {
   def update(): Unit = {
     val left_size = if (left != null) left.size else 0
-    val right_size = if (left != null) left.size else 0
+    val right_size = if (right != null) right.size else 0
     size = left_size + right_size + 1
   }
 }
@@ -87,7 +103,7 @@ case class Treap[K: Ordering: ClassTag](var root: TreapNode[K]) extends Index wi
     else getCount(p.right, key)
   }
 
-  def getCount(key: K): Int = getCount(key)
+  def getCount(key: K): Int = getCount(root, key)
 
   private def find(p: TreapNode[K], key: K): Array[Int] = {
     if (p == null) Array()


### PR DESCRIPTION
- fixed https://github.com/InitialDLab/Simba/issues/27 and https://github.com/InitialDLab/Simba/issues/25
- fixed some mistakes in [Treap](https://github.com/Skyprophet/Simba/blob/feature-treap/engine/sql/core/src/main/scala/org/apache/spark/sql/index/Treap.scala#L18)
- update `selectivityLevel`'s default value to 1
- fixed the error that it doesn't `intersect` with `circleRange` results when full scan, see [IndexedRelationScan.scala#L296-L302](https://github.com/Skyprophet/Simba/blob/feature-treap/engine/sql/core/src/main/scala/org/apache/spark/sql/index/IndexedRelationScan.scala#L296)
